### PR TITLE
CI: harden Pages workflow — build master+develop, deploy master only

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -1,18 +1,10 @@
 name: "Build and Deploy"
 
 on:
+  # Build on every branch push; deploy is gated to master below.
   push:
-    branches:
-      - main
-      - master
-      # Build-only check for the working branch (deploy job is gated below)
-      - develop
-    paths-ignore:
-      - .gitignore
-      - README.md
-      - LICENSE
-
-  # Allows you to run this workflow manually from the Actions tab
+  pull_request:
+  # Manual runs from the Actions tab (deploy still only if the run is on master)
   workflow_dispatch:
 
 permissions:
@@ -20,9 +12,9 @@ permissions:
   pages: write
   id-token: write
 
-# Allow one concurrent deployment
+# Per-ref concurrency so a push to develop cannot cancel an in-flight master deploy.
 concurrency:
-  group: "pages"
+  group: pages-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -51,21 +43,23 @@ jobs:
           JEKYLL_ENV: "production"
 
       - name: Test site
-        # Non-blocking for now — tighten once the migration has settled.
+        # Non-blocking — tighten later if you want the build to fail on link errors.
         continue-on-error: true
         run: |
           bundle exec htmlproofer _site \
             \-\-disable-external \
             \-\-ignore-urls "/^http:\/\/127.0.0.1/,/^http:\/\/0.0.0.0/,/^http:\/\/localhost/"
 
+      # Artifact is only needed for GitHub Pages deploy (master).
       - name: Upload site artifact
+        if: github.ref == 'refs/heads/master'
         uses: actions/upload-pages-artifact@v5
         with:
           path: "_site${{ steps.pages.outputs.base_path }}"
 
   deploy:
-    # Only deploy from the default branch; other branches just verify the build.
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    # Live site updates only from master.
+    if: github.ref == 'refs/heads/master'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -1,10 +1,16 @@
 name: "Build and Deploy"
 
 on:
-  # Build on every branch push; deploy is gated to master below.
   push:
-  pull_request:
-  # Manual runs from the Actions tab (deploy still only if the run is on master)
+    branches:
+      - master
+      - develop
+    paths-ignore:
+      - .gitignore
+      - README.md
+      - LICENSE
+
+  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 permissions:
@@ -12,7 +18,7 @@ permissions:
   pages: write
   id-token: write
 
-# Per-ref concurrency so a push to develop cannot cancel an in-flight master deploy.
+# Per-ref concurrency so a develop push cannot cancel an in-flight master deploy.
 concurrency:
   group: pages-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -43,14 +49,14 @@ jobs:
           JEKYLL_ENV: "production"
 
       - name: Test site
-        # Non-blocking — tighten later if you want the build to fail on link errors.
+        # Non-blocking for now — tighten once the migration has settled.
         continue-on-error: true
         run: |
           bundle exec htmlproofer _site \
             \-\-disable-external \
             \-\-ignore-urls "/^http:\/\/127.0.0.1/,/^http:\/\/0.0.0.0/,/^http:\/\/localhost/"
 
-      # Artifact is only needed for GitHub Pages deploy (master).
+      # Artifact only needed when deploying (master).
       - name: Upload site artifact
         if: github.ref == 'refs/heads/master'
         uses: actions/upload-pages-artifact@v5


### PR DESCRIPTION
## Summary

   Small follow-up to the Pages GitHub Actions workflow. Deploy was already
   limited in practice; this makes the gates stricter and safer.

   ## Changes (`.github/workflows/pages-deploy.yml`)

   | Behavior | Before | After |
   |---|---|---|
   | **Build on** | `main`, `master`, `develop` | `master`, `develop` |
   | **Deploy on** | `master`, `main`, or any `workflow_dispatch` | **`master` only** |
   | **Upload Pages artifact** | Every build (including develop) | **Master only** |
   | **Concurrency** | Single global `pages` group | **Per-ref** (`pages-…-refs/heads/master` vs `…/develop`) |

   ### Why
   - **Develop never deploys** the live site (explicit `if: github.ref == 'refs/heads/master'`).
   - **Develop builds cannot cancel** an in-flight master deploy (per-ref concurrency).
   - **No Pages artifact** on develop (artifact is only for deploy).

   ## Test plan
   - [ ] Push/merge to `develop` → Actions runs **build** only (no deploy job / no artifact upload)
   - [ ] Merge to `master` → build + upload artifact + **deploy** succeeds
   - [ ] Live site still updates only from `master`