### PR TITLE
Fix nginx HTTPS links; stop using series cards as post previews

### DIFF
--- a/_posts/2023-04-08-NGINX-Configuration.md
+++ b/_posts/2023-04-08-NGINX-Configuration.md
@@ -154,14 +154,14 @@ server {
 The document as referred to by [11] provides a detailed description of different cache parameters supported by NGINX. Would request you to check the page as well to get a firm grasp on different cache configurations.
 
 ### References
-1. [NGINX: Beginner’s Guide](http://nginx.org/en/docs/beginners_guide.html)
-2. [NGINX: Core functionality](http://nginx.org/en/docs/ngx_core_module.html)
-3. [How NGINX process requests](http://nginx.org/en/docs/http/request_processing.html)
+1. [NGINX: Beginner’s Guide](https://nginx.org/en/docs/beginners_guide.html)
+2. [NGINX: Core functionality](https://nginx.org/en/docs/ngx_core_module.html)
+3. [How NGINX process requests](https://nginx.org/en/docs/http/request_processing.html)
 4. [NGINX: Pitfalls and Common Mistakes](https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/)
 5. [NGINX: If is evil](https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/)
 6. [Understanding Nginx Server and Location Block Selection Algorithms](https://www.digitalocean.com/community/tutorials/understanding-nginx-server-and-location-block-selection-algorithms)
 7. [NGINX: HTTP Load Balancing](https://docs.nginx.com/nginx/admin-guide/load-balancer/http-load-balancer/)
 8. [NGINX: Securing HTTP Traffic](https://docs.nginx.com/nginx/admin-guide/security-controls/securing-http-traffic-upstream/)
 9. [A Guide to Caching with NGINX](https://www.nginx.com/blog/nginx-caching-guide/)
-10. [NGINX module ngx_http_proxy_module](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass)
+10. [NGINX module ngx_http_proxy_module](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass)
 11. [Forward query string parameters with proxy_pass directive in NGINX](https://stackoverflow.com/questions/8130692/how-can-query-string-parameters-be-forwarded-through-a-proxy-pass-with-nginx)

--- a/_posts/2023-09-03-Designing-Distributed-Systems-Ownership-Election.md
+++ b/_posts/2023-09-03-Designing-Distributed-Systems-Ownership-Election.md
@@ -1,7 +1,6 @@
 ---
 layout: post
 title: Designing Distributed Systems - Ownership Election
-image: /assets/img/series/designing-distributed-systems.png
 series: "Designing Distributed Systems"
 categories: ["Distributed Systems", "Patterns"]
 tags: [leader-election]

--- a/_posts/2024-08-17-Binary-Tree-Algo-Part-1.md
+++ b/_posts/2024-08-17-Binary-Tree-Algo-Part-1.md
@@ -1,7 +1,6 @@
 ---
 layout: post
 title: Binary Tree Algorithms - Part I
-image: /assets/img/series/binary-tree-problems.png
 series: "Binary Tree Problems"
 categories: ["Algorithms", "Problem Sets"]
 tags: [binary-tree, cpp]

--- a/_posts/2024-09-22-Binary-Tree-Algo-Part-2.md
+++ b/_posts/2024-09-22-Binary-Tree-Algo-Part-2.md
@@ -1,7 +1,6 @@
 ---
 layout: post
 title: Binary Tree Algorithms - Part II
-image: /assets/img/series/binary-tree-problems.png
 series: "Binary Tree Problems"
 categories: ["Algorithms", "Problem Sets"]
 tags: [binary-tree, cpp]

--- a/_posts/2025-01-19-Binary-Search-Problem-Set-Part-1.md
+++ b/_posts/2025-01-19-Binary-Search-Problem-Set-Part-1.md
@@ -1,7 +1,6 @@
 ---
 layout: post
 title: Binary Search Problem Sets Part I
-image: /assets/img/series/binary-search-problems.png
 series: "Binary Search Problems"
 categories: ["Algorithms", "Problem Sets"]
 tags: [binary-search, cpp]

--- a/_posts/2025-03-09-Binary-Search-Problem-Set-Part-2.md
+++ b/_posts/2025-03-09-Binary-Search-Problem-Set-Part-2.md
@@ -1,7 +1,6 @@
 ---
 layout: post
 title: Binary Search Problem Sets Part II
-image: /assets/img/series/binary-search-problems.png
 series: "Binary Search Problems"
 categories: ["Algorithms", "Problem Sets"]
 tags: [binary-search, cpp]

--- a/_posts/2025-03-16-BFS-Problem-Set-Part-1.md
+++ b/_posts/2025-03-16-BFS-Problem-Set-Part-1.md
@@ -1,7 +1,6 @@
 ---
 layout: post
 title: BFS Problem Sets Part I
-image: /assets/img/series/bfs-problems.png
 series: "BFS Problems"
 categories: ["Algorithms", "Problem Sets"]
 tags: [bfs, graph, cpp]

--- a/_posts/2025-04-01-BFS-Problem-Set-Part-2.md
+++ b/_posts/2025-04-01-BFS-Problem-Set-Part-2.md
@@ -1,7 +1,6 @@
 ---
 layout: post
 title: BFS Problem Sets Part II
-image: /assets/img/series/bfs-problems.png
 series: "BFS Problems"
 categories: ["Algorithms", "Problem Sets"]
 tags: [bfs, graph, cpp]

--- a/_posts/2025-05-03-DDIA-Chapter-2.md
+++ b/_posts/2025-05-03-DDIA-Chapter-2.md
@@ -1,7 +1,6 @@
 ---
 layout: post
 title: DDIA - Chap02 - Data Models
-image: /assets/img/series/designing-data-intensive-applications.png
 series: "Designing Data-Intensive Applications"
 categories: ["Databases", "DDIA"]
 tags: [ddia, data-models]

--- a/_posts/2025-05-17-DDIA-Chapter-4.md
+++ b/_posts/2025-05-17-DDIA-Chapter-4.md
@@ -1,7 +1,6 @@
 ---
 layout: post
 title: DDIA - Chap04 - Enconding and Evolution
-image: /assets/img/series/designing-data-intensive-applications.png
 series: "Designing Data-Intensive Applications"
 categories: ["Databases", "DDIA"]
 tags: [ddia, serialization]

--- a/_posts/2026-01-31-Postgres-Isolation-Model.md
+++ b/_posts/2026-01-31-Postgres-Isolation-Model.md
@@ -1,7 +1,6 @@
 ---
 layout: post
 title: PostgreSQL - Isolation Levels
-image: /assets/img/series/postgresql.png
 series: "PostgreSQL"
 categories: ["Databases", "PostgreSQL"]
 tags: [postgres, isolation-levels, mvcc]


### PR DESCRIPTION
## Summary

   Small content/UX fixes after the recent site overhaul.

   ## Changes

   ### 1. NGINX post — HTTPS links (`6a15af0`)
   htmlproofer was failing the **Test site** step (exit code 1 annotation) because four references used `http://nginx.org/...`. Updated them to `https://nginx.org/...`.

   ### 2. Drop series brand cards as post `image:` (`a8336ed`)
   Phase 6 set series OG banners as `image:` on 10 posts that had no content diagram. Chirpy used those as **home-card previews**, so posts like PostgreSQL Isolation Levels showed a generic purple series graphic.

   Removed `image: /assets/img/series/...` from:
   - Postgres Isolation Model
   - Binary Tree / Binary Search / BFS problem-set parts
   - DDIA chapters 2 & 4
   - Ownership Election

   Series cards remain under `assets/img/series/` for catalog/sharing use; those posts simply have no preview image.

   ## Test plan
   - [ ] Actions build: **Test site** step should no longer fail on nginx.org HTTP links
   - [ ] Home: Postgres Isolation (and the other listed posts) show **no** series-banner preview
   - [ ] Pins unchanged (RAFT etc. still pinned if that was intended)