### PR TITLE
Disable Edit this post on all posts (read-only UI)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -99,8 +99,7 @@ toc: true
 actions:
   # Display "Edit this post" action on each post page to encourage contributions.
   edit_post:
-    enabled: true
-    url: "https://github.com/tisan-das/tisan-das.github.io/edit/develop"
+    enabled: false
 
 comments:
   # GitHub Discussions via giscus (free on public repos).


### PR DESCRIPTION
## Summary

   Turn off Chirpy’s **Edit this post** action so the live site is read-only for visitors (no edit link on post pages).

   ## Change
   - `_config.yml`: `actions.edit_post.enabled: false` (removed the develop-branch edit URL)