### PR TITLE
fix: hide mismatched light/dark images based on active color mode

### DIFF
--- a/assets/css/jekyll-theme-chirpy.scss
+++ b/assets/css/jekyll-theme-chirpy.scss
@@ -297,7 +297,48 @@ html[data-mode='dark'] {
   }
 }
 
-/* Series navigation box (see _includes/series-nav.html) */
+/* ---- Dark/Light mode images ---- */
+
+/* Default (light mode): hide dark images, show light images */
+.popup.img-link.dark,
+img.dark {
+  display: none;
+}
+
+.popup.img-link.light,
+img.light {
+  display: inline-block;
+}
+
+/* Explicit dark mode */
+html[data-mode='dark'] {
+  .popup.img-link.light,
+  img.light {
+    display: none;
+  }
+
+  .popup.img-link.dark,
+  img.dark {
+    display: inline-block;
+  }
+}
+
+/* System dark mode preference (when no explicit mode is set) */
+@media (prefers-color-scheme: dark) {
+  html:not([data-mode]) {
+    .popup.img-link.light,
+    img.light {
+      display: none;
+    }
+
+    .popup.img-link.dark,
+    img.dark {
+      display: inline-block;
+    }
+  }
+}
+
+/* ---- Series navigation box (see _includes/series-nav.html) ---- */
 .series-nav {
   background: rgba(127, 127, 127, 0.08);
   border-left: 0.25rem solid var(--link-color, #2a9d8f);


### PR DESCRIPTION
### Problem

   Posts use Kramdown inline attribute lists to tag images with
   `{: .light}` and `{: .dark}` classes, expecting the theme to show
   only the variant matching the active color scheme. No CSS rule
   actually hid the non-matching variant, so **both images rendered
   side by side** on every page—cluttering content and confusing
   readers. For example:

   ```![alt](image.webp){: .light }```
   ```![alt](image-dark.webp){: .dark }```

   Both would appear stacked vertically regardless of whether the
   reader was in light or dark mode.

   ### Fix

   Added CSS rules to `assets/css/jekyll-theme-chirpy.scss` that:

   | Mode | `.light` | `.dark` |
   |------|----------|---------|
   | Light (default) | visible | hidden |
   | Explicit dark (`html[data-mode='dark']`) | hidden | visible |
   | System dark (`prefers-color-scheme: dark`, no explicit mode) | hidden | visible |
   | Images with neither class (e.g. `index_corruption_strategies.webp`) | unchanged | unchanged |

   Selectors target both:
   - `a.popup.img-link.light` / `.dark` (Chirpy glightbox wrapper), and
   - `img.light` / `img.dark` (bare images, forward compatibility)

   The rules reuse the same `data-mode` attribute already toggled by
   Chirpy's mode switcher—no JavaScript changes needed.

   ### Affected content

   Every post that uses the dual-image pattern:
   Postgres Internals I, DDIA chapters, system design deep-dives,
   and all other articles with dark-aware diagrams.