### PR TITLE
feat: register Production RAG in the series catalog

### DIFF
--- a/_data/series.yml
+++ b/_data/series.yml
@@ -49,17 +49,22 @@
   description: "Large language models and retrieval-augmented generation for semantic search."
   order: 10
 
+- name: "Production RAG"
+  slug: production-rag
+  description: "An eight-part build guide — from PDF extraction and chunking through hybrid search, multimodal, knowledge graphs, grounded generation, and production operations."
+  order: 11
+
 - name: "Binary Tree Problems"
   slug: binary-tree-problems
   description: "C++ problem sets on binary tree traversals and classic tree algorithms."
-  order: 11
+  order: 12
 
 - name: "Binary Search Problems"
   slug: binary-search-problems
   description: "C++ problem sets on binary search over answers, rotated arrays, and variants."
-  order: 12
+  order: 13
 
 - name: "BFS Problems"
   slug: bfs-problems
   description: "C++ graph BFS problem sets — shortest paths, grids, and multi-source search."
-  order: 13
+  order: 14


### PR DESCRIPTION

   The 8-part Production RAG series was merged in #135 but wasn't
   visible on the `/series/` page because it was missing from the
   catalog in `_data/series.yml`.

   This adds the entry:

   ```yaml
   - name: "Production RAG"
     slug: production-rag
     description: "An eight-part build guide — from PDF extraction
                   and chunking through hybrid search, multimodal,
                   knowledge graphs, grounded generation, and
                   production operations."
     order: 11
 ```

 The /series/ page uses this file to discover and list series.
 Without it, the series-nav rendered inside posts but the series
 was absent from the series index.