### PR TITLE
style: change disclaimer tense from 'was drafted' to 'is drafted'

### DIFF
--- a/_posts/2026-06-07-Production-RAG-Pipeline-Anatomy.md
+++ b/_posts/2026-06-07-Production-RAG-Pipeline-Anatomy.md
@@ -12,7 +12,7 @@ Retrieval-augmented generation looks deceptively simple. Split the documents, em
 
 {% include series-nav.html %}
 
-> **Disclaimer.** This post was drafted with assistance from large language models (Claude Opus 4.8 and DeepSeek V4 Pro) based on conversations exploring production RAG concepts. All content has been reviewed, edited, and verified by a human author.
+> **Disclaimer.** This post is drafted with assistance from large language models (Claude Opus 4.8 and DeepSeek V4 Pro) based on conversations exploring production RAG concepts. All content has been reviewed, edited, and verified by a human author.
 {: .prompt-info }
 
 > **Reference stack.** The reference implementation assumed throughout is a Go service using [sqlite-vec](https://github.com/asg017/sqlite-vec) for dense vectors, SQLite's [FTS5](https://www.sqlite.org/fts5.html) for BM25 keyword search, and a hosted model provider for embeddings, vision transcription and generation. None of the ideas are specific to that stack, but having a concrete one keeps the discussion honest about cost and failure modes.

--- a/_posts/2026-06-14-Production-RAG-PDF-Extraction.md
+++ b/_posts/2026-06-14-Production-RAG-PDF-Extraction.md
@@ -12,7 +12,7 @@ A PDF is not a document in any structured sense. Rooted in PostScript, it is a l
 
 {% include series-nav.html %}
 
-> **Disclaimer.** This post was drafted with assistance from large language models (Claude Opus 4.8 and DeepSeek V4 Pro) based on conversations exploring production RAG concepts. All content has been reviewed, edited, and verified by a human author.
+> **Disclaimer.** This post is drafted with assistance from large language models (Claude Opus 4.8 and DeepSeek V4 Pro) based on conversations exploring production RAG concepts. All content has been reviewed, edited, and verified by a human author.
 {: .prompt-info }
 
 ## The parser landscape

--- a/_posts/2026-06-21-Production-RAG-Chunking.md
+++ b/_posts/2026-06-21-Production-RAG-Chunking.md
@@ -12,7 +12,7 @@ A chunk is the smallest thing retrieval can return. You never get half a chunk, 
 
 {% include series-nav.html %}
 
-> **Disclaimer.** This post was drafted with assistance from large language models (Claude Opus 4.8 and DeepSeek V4 Pro) based on conversations exploring production RAG concepts. All content has been reviewed, edited, and verified by a human author.
+> **Disclaimer.** This post is drafted with assistance from large language models (Claude Opus 4.8 and DeepSeek V4 Pro) based on conversations exploring production RAG concepts. All content has been reviewed, edited, and verified by a human author.
 {: .prompt-info }
 
 ![A chunk boundary that destroys the answer](/images/rag/03-chunking/01-chunk-boundary-failure.webp)

--- a/_posts/2026-06-28-Production-RAG-Hybrid-Search.md
+++ b/_posts/2026-06-28-Production-RAG-Hybrid-Search.md
@@ -12,7 +12,7 @@ Ask a RAG system *"how do I shut down an instance"* and keyword search returns n
 
 {% include series-nav.html %}
 
-> **Disclaimer.** This post was drafted with assistance from large language models (Claude Opus 4.8 and DeepSeek V4 Pro) based on conversations exploring production RAG concepts. All content has been reviewed, edited, and verified by a human author.
+> **Disclaimer.** This post is drafted with assistance from large language models (Claude Opus 4.8 and DeepSeek V4 Pro) based on conversations exploring production RAG concepts. All content has been reviewed, edited, and verified by a human author.
 {: .prompt-info }
 
 ## Embeddings and the dot product

--- a/_posts/2026-07-05-Production-RAG-Multimodal.md
+++ b/_posts/2026-07-05-Production-RAG-Multimodal.md
@@ -12,7 +12,7 @@ Text retrieval works because both sides of the comparison are text living in one
 
 {% include series-nav.html %}
 
-> **Disclaimer.** This post was drafted with assistance from large language models (Claude Opus 4.8 and DeepSeek V4 Pro) based on conversations exploring production RAG concepts. All content has been reviewed, edited, and verified by a human author.
+> **Disclaimer.** This post is drafted with assistance from large language models (Claude Opus 4.8 and DeepSeek V4 Pro) based on conversations exploring production RAG concepts. All content has been reviewed, edited, and verified by a human author.
 {: .prompt-info }
 
 ## Two architectures

--- a/_posts/2026-07-12-Production-RAG-Entities-And-Graphs.md
+++ b/_posts/2026-07-12-Production-RAG-Entities-And-Graphs.md
@@ -12,7 +12,7 @@ At some point in every RAG project, a category of question stops working and no 
 
 {% include series-nav.html %}
 
-> **Disclaimer.** This post was drafted with assistance from large language models (Claude Opus 4.8 and DeepSeek V4 Pro) based on conversations exploring production RAG concepts. All content has been reviewed, edited, and verified by a human author.
+> **Disclaimer.** This post is drafted with assistance from large language models (Claude Opus 4.8 and DeepSeek V4 Pro) based on conversations exploring production RAG concepts. All content has been reviewed, edited, and verified by a human author.
 {: .prompt-info }
 
 ![Matching failure versus reachability failure](/images/rag/06-entities-graphs/01-two-retrieval-failures.webp)

--- a/_posts/2026-07-19-Production-RAG-Grounded-Generation.md
+++ b/_posts/2026-07-19-Production-RAG-Grounded-Generation.md
@@ -12,7 +12,7 @@ Retrieval can succeed completely and the answer can still be wrong. The model re
 
 {% include series-nav.html %}
 
-> **Disclaimer.** This post was drafted with assistance from large language models (Claude Opus 4.8 and DeepSeek V4 Pro) based on conversations exploring production RAG concepts. All content has been reviewed, edited, and verified by a human author.
+> **Disclaimer.** This post is drafted with assistance from large language models (Claude Opus 4.8 and DeepSeek V4 Pro) based on conversations exploring production RAG concepts. All content has been reviewed, edited, and verified by a human author.
 {: .prompt-info }
 
 ## Hallucination detection as an NLI problem

--- a/_posts/2026-07-26-Production-RAG-Evaluation-And-Operations.md
+++ b/_posts/2026-07-26-Production-RAG-Evaluation-And-Operations.md
@@ -12,7 +12,7 @@ Seven posts of machinery, and none of it is trustworthy until you can answer one
 
 {% include series-nav.html %}
 
-> **Disclaimer.** This post was drafted with assistance from large language models (Claude Opus 4.8 and DeepSeek V4 Pro) based on conversations exploring production RAG concepts. All content has been reviewed, edited, and verified by a human author.
+> **Disclaimer.** This post is drafted with assistance from large language models (Claude Opus 4.8 and DeepSeek V4 Pro) based on conversations exploring production RAG concepts. All content has been reviewed, edited, and verified by a human author.
 {: .prompt-info }
 
 ## Every retrieval metric is one confusion matrix


### PR DESCRIPTION

   Minor wording fix across all 8 Production RAG posts:

     - This post was drafted with assistance...
     + This post is drafted with assistance...

   Present tense reads better for a persistent note that stays
   with the post indefinitely.

