### PR TITLE
Fix content inconsistencies across the Production RAG series

### DIFF
--- a/_posts/2026-06-21-Production-RAG-Chunking.md
+++ b/_posts/2026-06-21-Production-RAG-Chunking.md
@@ -95,7 +95,7 @@ func coalesceRunts(chunks []chunk, max int) []chunk {
 }
 ```
 
-> Accept a slightly oversized chunk rather than a runt. Then generalise the rule: enforce a hard minimum chunk size of around 200 characters everywhere, with the single exception of a document that produces exactly one chunk. Any chunk below that floor is a length-normalization hazard regardless of what produced it.
+> Accept a slightly oversized chunk rather than a runt. Then generalise the rule: enforce the 25%-of-max floor everywhere, with the single exception of a document that produces exactly one chunk. Any chunk below that floor is a length-normalization hazard regardless of what produced it.
 {: .prompt-tip }
 
 Note the loop runs **backward over the whole chunk list**, not forward and not per-section. A mid-section table can shed a runt too, and merging one runt can make the previous chunk newly eligible.
@@ -145,7 +145,7 @@ Maintain a heading stack with one extra bit per frame — `inheritable bool`, se
 
 ## Three numbers to keep in config
 
-`maxChunkChars` (1,800 is a reasonable default), `chunkOverlapChars` (150), and the runt floor (200 characters, or 25% of max). Log the chunk-length distribution after every ingestion run — a sudden shift in that histogram is either a corpus change or a regression, and you want to know which one before your users do.
+`maxChunkChars` (1,800 is a reasonable default), `chunkOverlapChars` (150), and the runt floor (25% of max — 450 characters at the default). Log the chunk-length distribution after every ingestion run — a sudden shift in that histogram is either a corpus change or a regression, and you want to know which one before your users do.
 
 ## What comes next
 

--- a/_posts/2026-07-05-Production-RAG-Multimodal.md
+++ b/_posts/2026-07-05-Production-RAG-Multimodal.md
@@ -33,8 +33,8 @@ Store the transcription in the retrieval index, store the original image in a bl
 
 ```sql
 CREATE TABLE chunks(
-  id INTEGER PRIMARY KEY, doc_id TEXT, text TEXT,
-  type TEXT DEFAULT 'text',    -- 'text' | 'image_transcript'
+  id INTEGER PRIMARY KEY, doc_id TEXT, page INTEGER, text TEXT,
+  type TEXT DEFAULT 'text',    -- 'text' | 'table' | 'image_transcript'
   source_ref TEXT,             -- s3://bucket/img/fig_042.png when type='image_transcript'
   transcriber_version TEXT     -- lets you re-transcribe selectively after a prompt change
 );

--- a/_posts/2026-07-12-Production-RAG-Entities-And-Graphs.md
+++ b/_posts/2026-07-12-Production-RAG-Entities-And-Graphs.md
@@ -82,12 +82,19 @@ For matching failures, enrichment appends synthetic retrieval handles to a chunk
 
 ```sql
 -- index_text is what retrieval sees.  display_text is what the user sees.
-UPDATE chunks SET index_text =
-  heading_path || x'0a' || enrichment || x'0a' || overlap_prefix || x'0a' || body;
+ALTER TABLE chunks ADD COLUMN index_text TEXT;
+ALTER TABLE chunks ADD COLUMN display_text TEXT;
 
--- Column weights keep synthetic text from outbidding real text:
--- bm25(chunks_fts, 4.0 /* body */, 1.5 /* enrichment */, 2.0 /* heading */)
+UPDATE chunks SET
+  index_text  = heading_path || x'0a' || enrichment || x'0a' || overlap_prefix || x'0a' || body,
+  display_text = body;
+
+-- the FTS5 from part 4 indexed `text`; rebuild it on the enriched column
+DROP TABLE IF EXISTS chunks_fts;
+CREATE VIRTUAL TABLE chunks_fts USING fts5(index_text, tokenize='porter unicode61');
 ```
+
+If your enrichment is heavy — many synthetic questions, long alias expansions — consider splitting `index_text` into separate FTS5 columns (body, enrichment, heading) so you can apply column weights in `bm25()` and keep synthetic text from outbidding the original prose.
 
 > **Index text and display text must be different columns.** Every synthetic addition — overlap, heading ancestry, enrichment — improves retrieval and pollutes citation. The moment you concatenate them into one stored string, users start seeing repeated sentences and machine-written questions inside quoted evidence. This is the load-bearing schema decision of the entire ingest side, and it is nearly free if you make it early and painful to retrofit if you do not.
 {: .prompt-tip }

--- a/_posts/2026-07-26-Production-RAG-Evaluation-And-Operations.md
+++ b/_posts/2026-07-26-Production-RAG-Evaluation-And-Operations.md
@@ -119,11 +119,14 @@ Every entry below appeared somewhere in this series. Together they are the reaso
 | Embedding model changed, index not re-embedded | 4 | `embedder_version` mismatch check |
 | BM25 sign confusion — FTS5 scores are negative | 4 | Unit test on a known ranking |
 | Both retrievers share a blind spot; RRF amplifies it | 4 | Reranker disagreement rate |
+| Embedding model silently truncates long chunks | 4 | Assert chunk token count < model max before embedding |
 | Image exceeds the vision cap, transcription is invented | 5 | Log image dimension distribution at ingest |
 | Entity filter matches nothing, producing empty answers | 6 | Empty-after-filter fallback and counter |
 | Hub node floods two-hop traversal | 6 | Fan-out cap and degree monitoring |
 | Wrong entity merge corrupts every traversal through it | 6 | High auto-merge bar; human review band |
 | Semantic cache serves the negated query | 7 | Tight threshold; cache-hit audit sample |
+| Stale cache after document re-ingestion | 7 | Key by document-set version; flush on re-ingest |
+| Cache shared across permission scopes leaks data | 7 | Cache key must include permission scope or be per-principal |
 | Confused deputy — service identity, not user identity | 8 | Principal propagated on every trace |
 | ACL drift — index remembers old permissions | 8 | Staleness SLO and sync alerts |
 


### PR DESCRIPTION
Five corrections identified during a content review of all eight posts.

   1. Runt floor math contradiction in Part 3 Chunking
      The config section stated the runt floor as 200 characters or 25 percent of
      max, but 25 percent of 1800 equals 450. The prose now consistently uses 25
      percent of max, which is what the code already implements.

   2. FTS5 indexed text but enrichment went into index_text in Part 6
      Part 4 defined FTS5 on the text column, but Part 6 wrote enrichment into a
      new index_text column without updating the FTS5 definition. The index is now
      explicitly rebuilt on index_text. The column-weight concept is preserved as
      prose below the code block.

   3. type enum lost the table value between Part 1 and Part 5
      Part 1 defined the type column as text table or image_transcript. Part 5
      dropped table without explanation. Restored since tables have distinct
      chunking rules and a meaningful type marker at query time.

   4. page column disappeared from the chunks schema after Part 1
      Part 1 defined page INTEGER for citations. Part 5 had the most complete
      schema but was missing it. Added back to Part 5.

   5. Consolidated silent-failure table in Part 8 was missing three entries
      Embedding model truncation from Part 4, stale cache after document
      re-ingestion from Part 7, and cache leaking across permission scopes from
      Part 7 were all described as silent failures but did not appear in the final
      table. All three added in correct post-number order.